### PR TITLE
Add method to extract domain

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -6,6 +6,21 @@ require 'digest/md5'
 require 'nokogiri'
 require 'yaml'
 
+module Addressable
+  class URI
+    def domain
+      begin
+        dp = Domainatrix.parse(self)
+      rescue
+        return nil
+      end
+
+      dom = dp.public_suffix
+      dom = dp.domain.downcase + "." + dom unless dp.domain.empty?
+    end
+  end
+end
+
 module PostRank
   module URI
 
@@ -171,3 +186,4 @@ module PostRank
 
   end
 end
+

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -265,6 +265,31 @@ describe PostRank::URI do
         i.last.should == 'link to stuff'
       end
     end
-  end
 
+    context 'domain extraction' do
+      url_list = {"http://alex.pages.example.com" => "example.com",
+                  "alex.pages.example.com" => "example.com",
+                  "http://example.com/2011/04/01/blah" => "example.com",
+                  "http://example.com" => "example.com",
+                  "example.com" => "example.com",
+                  "ExampLe.com" => "example.com",
+                  "ExampLe.com:3000" => "example.com",
+                  "http://alex.pages.example.COM" => "example.com",
+                  "http://www.example.ag.it/2011/04/01/blah" => "example.ag.it",
+                  "ftp://www.example.com/2011/04/01/blah" => nil,
+                  "http://com" => nil,
+                  "http://alex.pages.examplecom" => nil,
+                  "example" => nil,
+                  "http://127.0.0.1" => nil,
+                  "localhost" => nil
+                  }
+
+       url_list.each_pair do |url, expected_result|
+         it "should extract #{expected_result.inspect} from #{url}" do
+            u = PostRank::URI.parse(url)
+            u.domain.should == expected_result
+         end
+       end
+    end
+  end
 end


### PR DESCRIPTION
Addressable provides the host method, but no way to just get domain and TLD. 
