### PR TITLE
remove hashbangs from mobile twitter urls

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -170,7 +170,7 @@ module PostRank
       end
       u.query_values = q
 
-      if u.host == 'twitter.com' && u.fragment && u.fragment.match(/^!(.*)/)
+      if u.host =~ /^(mobile\.)?twitter\.com$/ && u.fragment && u.fragment.match(/^!(.*)/)
         u.fragment = nil
         u.path = $1
       end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -226,6 +226,10 @@ describe PostRank::URI do
       e('test http://twitter.com/#!/igrigorik').should include('http://twitter.com/igrigorik')
     end
 
+    it "should extract mobile twitter links with hashbangs" do
+      e('test http://mobile.twitter.com/#!/_mm6').should include('http://mobile.twitter.com/_mm6')
+    end
+
     it "should handle a URL that comes after text without a space" do
       e("text:http://spn.tw/tfnLT").should include("http://spn.tw/tfnLT")
       e("text;http://spn.tw/tfnLT").should include("http://spn.tw/tfnLT")


### PR DESCRIPTION
Remove hashbangs from mobile.twitter.com urls the same as it currently does for twitter.com urls.
