### PR TITLE
remove feature query string parameter from youtube

### DIFF
--- a/lib/postrank-uri/c18n.yml
+++ b/lib/postrank-uri/c18n.yml
@@ -50,3 +50,5 @@
   - mod
   waomarketing.com:
   - nucrss
+  youtube.com:
+  - feature

--- a/spec/c18n_hosts.yml
+++ b/spec/c18n_hosts.yml
@@ -61,3 +61,6 @@
 
 - - http://www.waomarketing.com/blog/at-internet-white-paper-series/?nucrss=1
   - http://www.waomarketing.com/blog/at-internet-white-paper-series
+
+- - http://www.youtube.com/watch?v=RRBoPveyETc&feature=player_embedded
+  - http://www.youtube.com/watch?v=RRBoPveyETc


### PR DESCRIPTION
As far as I can tell the "feature" parameter is a tracking parameter that does not change the content of the page.
