### PR TITLE
Updated to use latest version of Addressable gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,6 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-require 'rspec'
 require 'rspec/core/rake_task'
 
-Rspec::Core::RakeTask.new do |t|
-  t.rspec_opts = '--color'
-end
+Rspec::Core::RakeTask.new(:spec)

--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -164,7 +164,7 @@ module PostRank
       u = parse(uri, opts)
       u = embedded(u)
 
-      if q = u.query_values(:notation => :flat_array)
+      if q = u.query_values(Array)
         q.delete_if { |k,v| C18N[:global].include?(k) }
         q.delete_if { |k,v| C18N[:hosts].find {|r,p| u.host =~ r && p.include?(k) } }
       end
@@ -230,4 +230,3 @@ module PostRank
     end
   end
 end
-

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,4 +1,7 @@
 require 'bundler'
 Bundler.setup
 
-require 'lib/postrank-uri'
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib')), __FILE__)
+
+require 'postrank-uri'


### PR DESCRIPTION
Version 2.3 of the Addressable gem introduced a change to the query_values method which breaks this gem. The fix is simple, and all specs pass once the change is applied.

@igrigorik  Not sure if you're still watching this repo, but I'd appreciate it if you could incorporate this fix into master and bump the rubygems version. I'll keep working from my fork in the mean time. Thanks!
