### PR TITLE
Make PostRank::URI.valid? work with punycode and Unicode domain names

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -224,7 +224,7 @@ module PostRank
       cleaned_uri = clean(uri, :raw => true)
 
       if host = cleaned_uri.host
-        is_valid = PublicSuffix.valid?(host)
+        is_valid = PublicSuffix.valid?(Addressable::IDNA.to_unicode(host))
       end
 
       is_valid

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -350,5 +350,13 @@ describe PostRank::URI do
     it 'marks www.test.com as valid' do
       PostRank::URI.valid?('http://www.test.com').should be_true
     end
+
+    it 'marks Unicode domain as valid (NOTE: works only with a scheme)' do
+      PostRank::URI.valid?('http://президент.рф').should be_true
+    end
+
+    it 'marks punycode domain domain as valid' do
+      PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai').should be_true
+    end
   end
 end


### PR DESCRIPTION
clean converts Unicode domains to punycode, but PublicSuffix does not
have punycode versions of the Unicode TLDs.

Therefore, convert back to Unicode before checking valid suffix.

This is one semi-related thing that is not fixed: "example.com" is considered valid, but a domain like "президент.рф" is not due to how the valid_domain regexp works in the parse method.
