### PR TITLE
Remove PHP session id parameter when canonicalizing URLs

### DIFF
--- a/lib/postrank-uri/c18n.yml
+++ b/lib/postrank-uri/c18n.yml
@@ -8,6 +8,7 @@
 - sms_ss        # addthis.com tracker
 - awesm         # awe.sm tracker
 - xtor          # AT Internet tracker
+- PHPSESSID     # Legacy PHP session identifier
 
 :hosts:
   nytimes.com:

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -122,6 +122,12 @@ describe PostRank::URI do
         c('igvita.com/?id=a&utm_source=a&awesm=b').should == 'http://igvita.com/?id=a'
         c('igvita.com/?id=a&sms_ss=a').should == 'http://igvita.com/?id=a'
       end
+
+      it "should remove PHPSESSID parameter" do
+        c('http://www.nachi.org/forum?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum?'
+        c('http://www.nachi.org/forum/?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum/?'
+        c('http://www.nachi.org/forum?id=123&PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum?id=123'
+      end
     end
 
     context "hashbang" do


### PR DESCRIPTION
Some really old PHP deployments still use URL parameter PHPSESSID for keeping track of user sessions. Those parameters should be removed during canonicalization.
