### PR TITLE
When canonicalizing a URL, do not keep an empty params string

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -161,7 +161,7 @@ module PostRank
         q.delete_if { |k,v| C18N[:global].include?(k) }
         q.delete_if { |k,v| C18N[:hosts].find {|r,p| u.host =~ r && p.include?(k) } }
       end
-      u.query_values = q
+      u.query_values = (q && q.any?) ? q : nil
 
       if u.host =~ /^(mobile\.)?twitter\.com$/ && u.fragment && u.fragment.match(/^!(.*)/)
         u.fragment = nil

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -113,6 +113,10 @@ describe PostRank::URI do
         c(url).should == url
       end
 
+      it "should remove ? if no more parameters left after cleaning up the URL" do
+        c("http://foo.com/bar?utm_source=a").should == "http://foo.com/bar"
+      end
+
       it "should remove Google Analytics parameters" do
         c('igvita.com/?id=a&utm_source=a').should == 'http://igvita.com/?id=a'
         c('igvita.com/?id=a&utm_source=a&utm_valid').should == 'http://igvita.com/?id=a&utm_valid'
@@ -124,8 +128,8 @@ describe PostRank::URI do
       end
 
       it "should remove PHPSESSID parameter" do
-        c('http://www.nachi.org/forum?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum?'
-        c('http://www.nachi.org/forum/?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum/?'
+        c('http://www.nachi.org/forum?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum'
+        c('http://www.nachi.org/forum/?PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum/'
         c('http://www.nachi.org/forum?id=123&PHPSESSID=9ee2fb10b7274ef2b15d1d4006b8c8dd').should == 'http://www.nachi.org/forum?id=123'
       end
     end


### PR DESCRIPTION
When canonicalizing a URL, if we remove all params, I believe we do not need to keep an empty query string.

"http://foo.com/bar?utm_source=a" should be turned into "http://foo.com/bar" and not into "http://foo.com/bar?".
