### PR TITLE
Update nokogiri to ~> 1.6.1

### DIFF
--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   "~> 2.3.0"
   s.add_dependency "public_suffix", "~> 1.1.3"
-  s.add_dependency "nokogiri",      "~> 1.5.5"
+  s.add_dependency "nokogiri",      "~> 1.6.1"
 
   s.add_development_dependency "rspec"
 


### PR DESCRIPTION
Being pessimistically locked to Nokogiri 1.5.x is causing problems for us, so I changed it to 1.6. All specs pass.

However, Nokogiri 1.6 doesn't support Ruby 1.8.7 any more, so I would recommend cutting a new gem version if you merge this.
