### PR TITLE
Adding # encoding: utf-8 is required

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -1,4 +1,4 @@
-
+# encoding: utf-8
 require 'addressable/uri'
 require 'digest/md5'
 require 'nokogiri'


### PR DESCRIPTION
If "# encoding: utf-8" is missing, it's failing to start the app
