### PR TITLE
Update public_suffix to ~> 1.4.2

### DIFF
--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "postrank-uri"
 
   s.add_dependency "addressable",   "~> 2.3.0"
-  s.add_dependency "public_suffix", "~> 1.1.3"
+  s.add_dependency "public_suffix", "~> 1.4.2"
   s.add_dependency "nokogiri",      "~> 1.6.1"
 
   s.add_development_dependency "rspec"


### PR DESCRIPTION
The latest `public_suffix` release has better support for new gTLDs.

For example, on `master`:

```
> PostRank::URI.valid?('http://en.trademarks.directory')
=> false
```

but with this patch, `.directory` (and many others) are added as valid gTLDs:

```
> PostRank::URI.valid?('http://en.trademarks.directory')
=> true
```
