### PR TITLE
bump version to 1.0.19

### DIFF
--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.18"
+    VERSION = "1.0.19"
   end
 end


### PR DESCRIPTION
Hi Ilya!

Would it make sense to do an increment of tiny, since the dependencies have changed (`public_suffix`)? I'm trying to use `postrank-uri` as a dependency in a `.gemspec` file, where refs are not valid...

Thanks!
