### PR TITLE
Allow newer runtime dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg
 Gemfile.lock
+/gemfiles

--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,19 @@
+appraise "nokogiri-1.7" do
+  gem "nokogiri", "~> 1.7.0"
+end
+
+appraise "nokogiri-1.6" do
+  gem "nokogiri", "~> 1.6.1"
+end
+
+appraise "addressable-2.3" do
+  gem "addressable", "~> 2.3.0"
+end
+
+appraise "addressable-2.4" do
+  gem "addressable", "~> 2.4.0"
+end
+
+appraise "addressable-2.5" do
+  gem "addressable", "~> 2.5.0"
+end

--- a/README.md
+++ b/README.md
@@ -38,3 +38,28 @@ In a nutshell, we need to make sure that creative cases like the ones below all 
 As part of URI canonicalization the library will remove common tracking parameters from Google Analytics and several other providers. Beyond that, host-specific rules are also applied. For example, nytimes.com likes to add a 'partner' query parameter for tracking purposes, but which has no effect on the content - hence, it is removed from the URI. For full list, see the c14n.yml file.
 
 Detecting "duplicate URLs" is a hard problem to solve (expensive in all senses), instead we are compiling a manually assembled database. If you find cases which are missing, please do report them, or send us a pull request!
+
+## Development
+
+### Setup
+
+```
+bundle install
+```
+
+### Running tests
+
+```
+bundle exec rake
+```
+
+### Running dependency appraisals
+
+To verify `postrake-uri` works with different versions of its runtime dependencies you can run:
+
+```
+bundle exec appraisal install
+bundle exec rake appraisal
+```
+
+This will execute the test suite with different versions of the dependencies.

--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,6 @@ Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
+task :default => :spec
+
+require 'appraisal'

--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -9,7 +9,7 @@ module Addressable
   class URI
     def domain
       host = self.host
-      (host && PublicSuffix.valid?(host)) ? PublicSuffix.parse(host).domain : nil
+      (host && PublicSuffix.valid?(host, default_rule: nil)) ? PublicSuffix.parse(host).domain : nil
     end
 
     def normalized_query
@@ -97,7 +97,7 @@ module PostRank
       urls = []
       text.to_s.scan(URIREGEX[:valid_url]) do |all, before, url, protocol, domain, path, query|
         # Only extract the URL if the domain is valid
-        if PublicSuffix.valid?(domain)
+        if PublicSuffix.valid?(domain, default_rule: nil)
           url = clean(url)
           urls.push url.to_s
         end
@@ -225,7 +225,7 @@ module PostRank
       cleaned_uri = clean(uri, :raw => true)
 
       if host = cleaned_uri.host
-        is_valid = PublicSuffix.valid?(Addressable::IDNA.to_unicode(host))
+        is_valid = PublicSuffix.valid?(Addressable::IDNA.to_unicode(host), default_rule: nil)
       end
 
       is_valid

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "postrank-uri"
 
-  s.add_dependency "addressable",   "~> 2.3.0"
+  s.add_dependency "addressable",   ">= 2.3.0", "< 2.6"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "postrank-uri"
 
   s.add_dependency "addressable",   "~> 2.3.0"
-  s.add_dependency "public_suffix", "~> 1.4.2"
+  s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 
   s.add_development_dependency "rspec"

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   "~> 2.3.0"
   s.add_dependency "public_suffix", "~> 1.4.2"
-  s.add_dependency "nokogiri",      "~> 1.6.1"
+  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 
   s.add_development_dependency "rspec"
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |s|
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
 
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "appraisal", ">= 2.0.0", "< 3.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -350,23 +350,23 @@ describe PostRank::URI do
 
   context 'valid?' do
     it 'marks incomplete URI string as invalid' do
-      PostRank::URI.valid?('/path/page.html').should be_false
+      PostRank::URI.valid?('/path/page.html').should be false
     end
 
     it 'marks www.test.c as invalid' do
-      PostRank::URI.valid?('http://www.test.c').should be_false
+      PostRank::URI.valid?('http://www.test.c').should be false
     end
 
     it 'marks www.test.com as valid' do
-      PostRank::URI.valid?('http://www.test.com').should be_true
+      PostRank::URI.valid?('http://www.test.com').should be true
     end
 
     it 'marks Unicode domain as valid (NOTE: works only with a scheme)' do
-      PostRank::URI.valid?('http://президент.рф').should be_true
+      PostRank::URI.valid?('http://президент.рф').should be true
     end
 
     it 'marks punycode domain domain as valid' do
-      PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai').should be_true
+      PostRank::URI.valid?('xn--d1abbgf6aiiy.xn--p1ai').should be true
     end
   end
 end


### PR DESCRIPTION
Hi there! I'm trying to update a few dependencies but can't because `postrank-uri` depends on outdated versions of some runtime dependencies. These are listed here on gemnasium:

https://gemnasium.com/github.com/postrank-labs/postrank-uri

This PR allows newer versions of Nokogiri and Addressable to be used (I've done so locally and the tests pass). I've also raised the minimum version of PublicSuffix to greater than or equal to `2.0` since this is a hard requirement for newer versions of Addressable. 

The PublicSuffix upgrade would change the behaviour by default (counting `lets` of `yah.lets` as a valid TLD). I've preserved the old behaviour as described in the PublicSuffix upgrade guide, because it matches the specs in the test suite, and we don't want a change in behaviour for minor releases.

Would it be possible to make a new release with these changes?