### PR TITLE
Preserve escaping of reserved characters (%26 and %3F)

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -86,7 +86,7 @@ module PostRank
           )
         }iox;
 
-    URIREGEX[:encoded_question_mark] = '%3F'
+    URIREGEX[:reserved_characters] = /%3F|%26/i
     URIREGEX[:escape]   = /([^ a-zA-Z0-9_.-]+)/x
     URIREGEX[:unescape] = /(%[0-9a-fA-F]{2})/x
     URIREGEX.each_pair{|k,v| v.freeze }
@@ -132,11 +132,11 @@ module PostRank
     def unescape(uri)
       u = parse(uri)
       u.query = u.query.tr('+', ' ') if u.query
-      u.to_s.gsub(URIREGEX[:unescape]) do |match|
-        if match == URIREGEX[:encoded_question_mark]
-          match
+      u.to_s.gsub(URIREGEX[:unescape]) do |encoded|
+        if encoded.match? URIREGEX[:reserved_characters]
+          encoded
         else
-          [match.delete('%')].pack('H*')
+          [encoded.delete('%')].pack('H*')
         end
       end
     end

--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -86,8 +86,9 @@ module PostRank
           )
         }iox;
 
+    URIREGEX[:encoded_question_mark] = '%3F'
     URIREGEX[:escape]   = /([^ a-zA-Z0-9_.-]+)/x
-    URIREGEX[:unescape] = /((?:%[0-9a-fA-F]{2})+)/x
+    URIREGEX[:unescape] = /(%[0-9a-fA-F]{2})/x
     URIREGEX.each_pair{|k,v| v.freeze }
 
     module_function
@@ -131,8 +132,12 @@ module PostRank
     def unescape(uri)
       u = parse(uri)
       u.query = u.query.tr('+', ' ') if u.query
-      u.to_s.gsub(URIREGEX[:unescape]) do
-        [$1.delete('%')].pack('H*')
+      u.to_s.gsub(URIREGEX[:unescape]) do |match|
+        if match == URIREGEX[:encoded_question_mark]
+          match
+        else
+          [match.delete('%')].pack('H*')
+        end
       end
     end
 

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -195,12 +195,17 @@ describe PostRank::URI do
     end
 
     context "reserved characters" do
-      it "preserves encoded question marks in the path" do
+      it "preserves encoded question marks" do
         c('http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_%28U.S._TV_series%29').
           should == 'http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_(U.S._TV_series)'
       end
 
-      it "preserves multiple question marks in the path" do
+      it "preserves encoded ampersands" do
+        c('http://example.com/?foo=BAR%26BAZ').
+          should == 'http://example.com/?foo=BAR%26BAZ'
+      end
+
+      it "preserves consecutive reserved characters" do
         c('http://example.com/so-quizical%3F%3F%3F?foo=bar').
           should == 'http://example.com/so-quizical%3F%3F%3F?foo=bar'
       end

--- a/spec/postrank-uri_spec.rb
+++ b/spec/postrank-uri_spec.rb
@@ -193,6 +193,18 @@ describe PostRank::URI do
         c(orig).should == clean
       end
     end
+
+    context "reserved characters" do
+      it "preserves encoded question marks in the path" do
+        c('http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_%28U.S._TV_series%29').
+          should == 'http://en.wikipedia.org/wiki/Whose_Line_Is_It_Anyway%3F_(U.S._TV_series)'
+      end
+
+      it "preserves multiple question marks in the path" do
+        c('http://example.com/so-quizical%3F%3F%3F?foo=bar').
+          should == 'http://example.com/so-quizical%3F%3F%3F?foo=bar'
+      end
+    end
   end
 
   context "hash" do


### PR DESCRIPTION
The `PostRank::URI.clean(uri)` method breaks URIs containing escaped reserved characters like %26 (&) and %3F (?).

These are no longer unescaped from any part of the URI during `#clean` / `#unescape`. It's my interpretation (hope this is correct!) they shouldn't be unescaped if they conflict with the character's purpose as a delimiter:

> If data for a URI component would conflict with a reserved
   character's purpose as a delimiter, then the conflicting data must be
   percent-encoded before the URI is formed.

As referenced in [RFC3986](https://tools.ietf.org/html/rfc3986#page-12).

---
Fixes issues #28 and #29