### PR TITLE
Update nokogiri to 1.8

### DIFF
--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   ">= 2.3.0", "< 2.6"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
-  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.8"
+  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.9"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
This allows nokogiri ~> 1.8, as 1.8.1 resolves a bunch of security issues.

See https://github.com/sparklemotion/nokogiri/issues/1673