### PR TITLE
Bump to version 1.0.23

### DIFF
--- a/lib/postrank-uri/version.rb
+++ b/lib/postrank-uri/version.rb
@@ -1,5 +1,5 @@
 module PostRank
   module URI
-    VERSION = "1.0.22"
+    VERSION = "1.0.23"
   end
 end


### PR DESCRIPTION
Would like to cut another release of this gem due to the security fix from 9a80a1f1.

Is a bump in the patch version enough? I can change this to 1.1.0 if we want to bump the minor version here. Just lmk! Thanks!!