### PR TITLE
Misc version updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
 before_install:
   - gem install bundler
 install:

--- a/Appraisals
+++ b/Appraisals
@@ -1,9 +1,9 @@
-appraise "nokogiri-1.7" do
-  gem "nokogiri", "~> 1.7.0"
-end
+nokogiri_versions = ["1.8", "1.9", "1.10"]
 
-appraise "nokogiri-1.6" do
-  gem "nokogiri", "~> 1.6.1"
+nokogiri_versions.each do |version|
+  appraise "nokogiri-#{version}" do
+    gem "nokogiri", "~> #{version}.0"
+  end
 end
 
 appraise "addressable-2.3" do

--- a/Appraisals
+++ b/Appraisals
@@ -6,14 +6,10 @@ nokogiri_versions.each do |version|
   end
 end
 
-appraise "addressable-2.3" do
-  gem "addressable", "~> 2.3.0"
-end
+addressable_versions = ["2.4", "2.5", "2.6"]
 
-appraise "addressable-2.4" do
-  gem "addressable", "~> 2.4.0"
-end
-
-appraise "addressable-2.5" do
-  gem "addressable", "~> 2.5.0"
+addressable_versions.each do |version|
+  appraise "addressable-#{version}" do
+    gem "addressable", "~> #{version}.0"
+  end
 end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/postrank-uri.svg)](https://rubygems.org/gems/postrank-uri) [![Build Status](https://travis-ci.org/postrank-labs/postrank-uri.svg?branch=master)](https://travis-ci.org/postrank-labs/postrank-uri)
 
-A collection of convenience methods (Ruby 2.0+) for dealing with extracting, (un)escaping, normalization, and canonicalization of URIs. At PostRank we process over 20M URI associated activities each day, and we need to make sure that we can reliably extract the URIs from a variety of text formats, deal with all the numerous and creative ways users like to escape and unescape their URIs, normalize the resulting URIs, and finally apply a set of custom canonicalization rules to make sure that we can cross-reference when the users are talking about the same URL.
+A collection of convenience methods (Ruby 2.3+) for dealing with extracting, (un)escaping, normalization, and canonicalization of URIs. At PostRank we process over 20M URI associated activities each day, and we need to make sure that we can reliably extract the URIs from a variety of text formats, deal with all the numerous and creative ways users like to escape and unescape their URIs, normalize the resulting URIs, and finally apply a set of custom canonicalization rules to make sure that we can cross-reference when the users are talking about the same URL.
 
 In a nutshell, we need to make sure that creative cases like the ones below all resolve to same URI:
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "postrank-uri"
 
-  s.add_dependency "addressable",   ">= 2.3.0", "< 2.6"
+  s.add_dependency "addressable",   ">= 2.4.0"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.8.0"
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = "URI normalization, c14n, escaping, and extraction"
   s.description = s.summary
   s.license     = 'MIT'
-  s.required_ruby_version  = ">= 2.0.0"
+  s.required_ruby_version  = ">= 2.3.0"
 
   s.rubyforge_project = "postrank-uri"
 

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable",   ">= 2.3.0", "< 2.6"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
-  s.add_dependency "nokogiri",      ">= 1.6.1", "< 1.9"
+  s.add_dependency "nokogiri",      ">= 1.8.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Resolves https://github.com/postrank-labs/postrank-uri/issues/42

This updates the supported versions of ruby itself, and the nokogiri and addressable gems. I tried to pick what seem like reasonable versions given both gem histories and support for non-EOL'd rubies. I'm open to feedback on supporting earlier/later versions.

My main goal is to allow newer nokogiri versions.