### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version  = ">= 2.3.0"
 
-  s.rubyforge_project = "postrank-uri"
-
   s.add_dependency "addressable",   ">= 2.4.0"
   s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
   s.add_dependency "nokogiri",      ">= 1.8.0"


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.