### PR TITLE
Add Ruby 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: ruby
 cache: bundler
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.10
+  - 2.5.9
+  - 2.6.8
+  - 2.7.4
+  - 3.0.2
 before_install:
   - gem install bundler
 install:

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version  = ">= 2.3.0"
 
   s.add_dependency "addressable",   ">= 2.4.0"
-  s.add_dependency "public_suffix", ">= 2.0.0", "< 2.1"
+  s.add_dependency "public_suffix", ">= 2.0.0", "< 5"
   s.add_dependency "nokogiri",      ">= 1.8.0"
 
   s.add_development_dependency "rake"

--- a/postrank-uri.gemspec
+++ b/postrank-uri.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version  = ">= 2.3.0"
 
   s.add_dependency "addressable",   ">= 2.4.0"
-  s.add_dependency "public_suffix", ">= 2.0.0", "< 5"
+  s.add_dependency "public_suffix", ">= 4.0.0", "< 5"
   s.add_dependency "nokogiri",      ">= 1.8.0"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
If `public_suffix` 4.0.6 is installed, all tests pass under Ruby 3+.

Fixes #45.