### PR TITLE
Remove monkey patch from Addressable::URI#normalized_query so that it can be compatible with Addressable 2.8.2

### DIFF
--- a/lib/postrank-uri.rb
+++ b/lib/postrank-uri.rb
@@ -11,22 +11,6 @@ module Addressable
       host = self.host
       (host && PublicSuffix.valid?(host, default_rule: nil)) ? PublicSuffix.parse(host).domain : nil
     end
-
-    def normalized_query
-      @normalized_query ||= (begin
-        if self.query && self.query.strip != ''
-          (self.query.strip.split("&", -1).map do |pair|
-            Addressable::URI.normalize_component(
-              pair,
-              Addressable::URI::CharacterClasses::QUERY.sub("\\&", "")
-            )
-          end).join("&")
-        else
-          nil
-        end
-      end)
-    end
-
   end
 end
 
@@ -152,6 +136,7 @@ module PostRank
     end
 
     def normalize(uri, opts = {})
+      uri = uri.to_s.split(' ').first
       u = parse(uri, opts)
       u.path = u.path.gsub(URIREGEX[:double_slash_outside_scheme], '/')
       u.path = u.path.chomp('/') if u.path.size != 1


### PR DESCRIPTION
This fixes the error on https://github.com/postrank-labs/postrank-uri/issues/49

Removing the monkey patch entirely lead to the following error

```
/Users/eric.firth/.rbenv/versions/3.0.4/bin/ruby -I/Users/eric.firth/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib:/Users/eric.firth/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rspec-support-3.12.1/lib /Users/eric.firth/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
...........F...........................................................

Failures:

  1) PostRank::URI normalize cleans whitespace in PostRank::URIs
     Failure/Error: expect(n('http://igvita.com/a/../?  ')).to eq(igvita)

       expected: "http://igvita.com/"
            got: "http://igvita.com/?%20%20"

       (compared using ==)
     # ./spec/postrank-uri_spec.rb:77:in `block (3 levels) in <top (required)>'

Finished in 0.13964 seconds (files took 0.29346 seconds to load)
71 examples, 1 failure

Failed examples:

rspec ./spec/postrank-uri_spec.rb:76 # PostRank::URI normalize cleans whitespace in PostRank::URIs
```

So I split on whitespace and took the first item. I initially tried just stripping the URI as a string, but then got
```
     Failure/Error: expect(n('http://igvita.com/a/../? #test')).to eq(igvita)

       expected: "http://igvita.com/"
            got: "http://igvita.com/?%20"
```

Happy to make any changes needed.